### PR TITLE
updated contents of a step in simulator of exp10

### DIFF
--- a/src/lab/exp10/content.html
+++ b/src/lab/exp10/content.html
@@ -211,7 +211,7 @@ The yellow colored solution turns purple indicating the formation of fine colloi
 </li> 
 <li> Click on the spectrophotometer lid to open it.
 </li> 
-<li>  	Click on the cuvette to place it in the sample cell holder of the instrument.
+<li>  	Click on the Au seed solution cuvette to place it in the sample cell holder of the instrument.
 One has to use aqueous TX-100 solution as the sample blank or reference in this measurement. Here a double beam spectrophotometer is shown. 
 </li> 
 <li>  	Run the wavelength scan by clicking on the Computer monitor and then on the ‘Scan’ tab and observe the scan. In the real spectrophotometer, an appropriate wavelength range of incident light for the sample can be chosen and the wavelength scan are run via the accompanied computer software. One can run the scan in absorbance or transmittance mode. The scan data is stored in the computer. 


### PR DESCRIPTION
Simulator of exp10
After opening the lid of spectrophotometer for the first time ,it was actually given to click on the cuvette in simulator description but did not clearly mention on which cuvette a click has to be made.This issue is fixed